### PR TITLE
Remove "covers" annotations for static methods

### DIFF
--- a/tests/MageTest/Command/FactoryTest.php
+++ b/tests/MageTest/Command/FactoryTest.php
@@ -20,9 +20,6 @@ class FactoryTest extends PHPUnit_Framework_TestCase
         $this->config = $this->getMock('Mage\Config');
     }
 
-    /**
-     * @covers Factory::get
-     */
     public function testGet()
     {
         $command = Factory::get('add', $this->config);
@@ -31,16 +28,12 @@ class FactoryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Exception
-     * @covers Factory::get
      */
     public function testGetClassNotFoundException()
     {
         $command = Factory::get('commanddoesntexist', $this->config);
     }
 
-    /**
-     * @covers Factory::get
-     */
     public function testGetCustomCommand()
     {
         $this->getMockBuilder('Mage\\Command\\AbstractCommand')
@@ -60,7 +53,6 @@ class FactoryTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \Exception
      * @expectedExceptionMessage The command MyInconsistentCommand must be an instance of Mage\Command\AbstractCommand.
-     * @covers Factory::get
      */
     public function testGetInconsistencyException()
     {


### PR DESCRIPTION
With apologies! :)
I wanted you to add `@covers` annotations for Command factory tests but I hadn't noticed that those tests cover static methods. So when you try to run
```
bin/phpunit --coverage-text
```
tests don't run because 
```
Trying to @cover or @use not existing method "Factory::get".
```
So again, sorry. I didn't want to point something to correct, because here the fault is mine. So I'm making this PR.
Cheers!